### PR TITLE
Set card date to the future

### DIFF
--- a/LemonWayApp/app/controllers/scenario_controller.rb
+++ b/LemonWayApp/app/controllers/scenario_controller.rb
@@ -67,7 +67,7 @@ class ScenarioController < ApplicationController
 			:cardType 	=> "1",
 			:cardNumber => "5017670000006700",
 			:cardCode 	=> "123",
-			:cardDate 	=> "12/2016"
+			:cardDate 	=> 3.year.from_now.strftime("%m/%Y")
 		}
 		@rawRegisterCard 	= registerCard(@reqRegisterCard)
 		@resultRegisterCard	= handleResponse(@rawRegisterCard, "CARD").html_safe


### PR DESCRIPTION
Having a date in the past breaks the demo.

This will change the date to by dynamic while still supplying the desired format.